### PR TITLE
Provide deploy user with S3 object privileges

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -55,7 +55,8 @@ class ServiceDeployIAM extends cdk.Stack {
                          "s3:DeleteBucket",
                          "s3:GetBucketPolicy",
                          "s3:PutBucketPolicy",
-                         "s3:DeleteBucketPolicy"
+                         "s3:DeleteBucketPolicy",
+                         "s3:ListBucket"
                     ]
                })
           );

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -51,7 +51,11 @@ class ServiceDeployIAM extends cdk.Stack {
                     effect: Effect.ALLOW,
                     resources: s3DeploymentResources,
                     actions: [
-                         "s3:*",
+                         "s3:CreateBucket",
+                         "s3:DeleteBucket",
+                         "s3:GetBucketPolicy",
+                         "s3:PutBucketPolicy",
+                         "s3:DeleteBucketPolicy"
                     ]
                })
           );

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -38,10 +38,22 @@ class ServiceDeployIAM extends cdk.Stack {
           const cloudFormationStackResource = ``
           const eventBridgeResources = [`arn:aws:events:${region}:${accountId}:rule/${serviceName}*`]
           const s3DeploymentResources = [`arn:aws:s3:::${serviceName}*serverlessdeployment*`]
+          const s3DeploymentObjectResources = [`arn:aws:s3:::${serviceName}*serverlessdeployment*/*`]
           const ssmDeploymentResources = [`arn:aws:ssm:${region}:${accountId}:parameter/${serviceName}*`]
           const serviceRole = new Role(this, `ServiceRole-v${version}`, {
                assumedBy: new ServicePrincipal('cloudformation.amazonaws.com')
           });
+
+          // S3 Deployment Bucket managment
+          serviceRole.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: s3DeploymentResources,
+                    actions: [
+                         "s3:*",
+                    ]
+               })
+          );
 
           // S3 object policy 
           serviceRole.addToPolicy(
@@ -289,13 +301,14 @@ class ServiceDeployIAM extends cdk.Stack {
                })
           );
           
-          // Deployer user needs to be able to manage the deployment bucket
+          // Deployment bucket object managment
           deployGroup.addToPolicy(
                new PolicyStatement({
                     effect: Effect.ALLOW,
-                    resources: s3DeploymentResources,
-                    actions: [            
-                         "s3:*",
+                    resources: s3DeploymentObjectResources,
+                    actions: [
+                         "s3:PutObject",
+                         "s3:DeleteObject",
                     ]
                })
           );


### PR DESCRIPTION
The CloudFromation service role needs to be able to manage
the deployment bucket (create, deplete, etc) while the deploy
"user" needs to be able to manage the deployment assets within.