### PR TITLE
Do not export Version and role ARN

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -332,13 +332,11 @@ class ServiceDeployIAM extends cdk.Stack {
           new cdk.CfnOutput(this, 'DeployRoleArn', {
                value: serviceRole.roleArn,
                description: 'The ARN of the CloudFormation service role',
-               exportName: 'DeployRoleArn',
           });
 
           new cdk.CfnOutput(this, 'Version', {
                value: version,
                description: 'The version of the resources that are currently provisioned in this stack',
-               exportName: 'Version',
           });
 
           const parameterName = `/serverless-deploy-iam/${serviceName}/version`;


### PR DESCRIPTION
These only need to be outputs not exports. They do not need to be
referenced by other stacks.

This was causing issues with naming collisions when the stack was deployed into the same account twice.