### PR TITLE
Adding Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:16-alpine3.13
+ARG node_version=16-alpine3.13
+FROM node:${node_version}
 
 RUN mkdir /app /cdk /home/node/.config
 RUN chown node:node /app /cdk /home/node/.config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:16-alpine3.13
+
+RUN mkdir /app /cdk /home/node/.config
+RUN chown node:node /app /cdk /home/node/.config
+
+RUN apk update && \
+    apk add \
+      sudo python3 py3-pip bash shadow make g++ &&  \
+    pip3 --no-cache-dir install --upgrade awscli && \
+    rm -rf /var/cache/apk/*
+
+USER node
+WORKDIR /cdk
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+COPY --chown=node:node package.json ./
+COPY --chown=node:node package-lock.json ./
+
+RUN npm ci
+RUN npm install -g aws-cdk
+ENV PATH="/home/node/.npm-global/bin:${PATH}"
+
+WORKDIR /app
+USER root
+
+COPY entrypoint.sh /docker-entrypoint.sh
+RUN chmod 0755 /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This ensures all the commands are run inside the serverless-deploy-iam docker co
 
 Add the following to your .bashrc file:
 ```
-alias serverless-deploy-iam='docker run --rm -it --volume ~/.aws:/home/node/.aws --volume ~/.npm:/home/node/.npm --volume $PWD:/app aligent/cdk-serverless-deploy-iam'
+alias serverless-deploy-iam='docker run --rm -it --volume ~/.aws:/home/node/.aws --volume $HOME/.npm:/home/node/.npm --volume $PWD:/app aligent/cdk-serverless-deploy-iam'
 ```
 
 You will then need to reload your bashrc file, either by running `. ~/.bashrc` or starting a new terminal session.

--- a/README.md
+++ b/README.md
@@ -8,18 +8,30 @@ This stack will provision a CloudFormation IAM role with the required permission
 Services are then deployed referencing the role produced by this stack. This is done by adding the `provider.cfnRole` key to the project's `serverless.yml`.
 This ARN is provided as a stack output.
 
-
 ## Usage
 This repository does not need to be forked, copied or imported. The intention is for it to be deployed *AS IS* into each environment for each service.
 Additional permissions should be added to this stack and feature flagged rather than being added ad hoc to the environment.
 
 This tool is philosophically similar to the [AWS CDK Bootstrap](https://github.com/aws/aws-cdk/blob/master/design/cdk-bootstrap.md) but specific to Aligent services IAM resources.
 
-### Parameters
+### Aliased Command
+This ensures all the commands are run inside the serverless-deploy-iam docker container so that you don't need clone the repo.
+
+Add the following to your .bashrc file:
+```
+alias serverless-deploy-iam='docker run --rm -it --volume ~/.aws:/home/node/.aws --volume ~/.npm:/home/node/.npm --volume $PWD:/app aligent/cdk-serverless-deploy-iam'
+```
+
+You will then need to reload your bashrc file, either by running `. ~/.bashrc` or starting a new terminal session.
+
+To deploy the IAM role, provide a profile and service name: `serverless-deploy-iam --profile <profile name> --service <service name>`.
+
+### Cloning the repo
+#### Parameters
 The CDK stack requires the service name to be provided as an environment variable.
 This is the name of the Serverless application.
 
-### Deploying:
+#### Deploying:
 The intention is that this stack is deployed manually using the CDK CLI by an IAM user with admin privileges.
 This should then be the last deployment into the environment from outside automated pipelines.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#set -x
+
+APP_ROOT="/app"
+
+DOCKER_UID=`stat -c "%u" $APP_ROOT`
+DOCKER_GID=`stat -c "%g" $APP_ROOT`
+
+INCUMBENT_USER=`getent passwd $DOCKER_UID | cut -d: -f1`
+INCUMBENT_GROUP=`getent group $DOCKER_GID | cut -d: -f1`
+
+#echo "Docker: uid = $DOCKER_UID, gid = $DOCKER_GID"
+#echo "Incumbent: user = $INCUMBENT_USER, group = $INCUMBENT_GROUP"
+
+userdel node
+groupadd -g ${DOCKER_GID} node
+useradd -g ${DOCKER_GID} --home-dir /home/node -s /bin/bash -u ${DOCKER_UID} node
+
+chown -R node:node /home/node/.config
+
+cd $APP_ROOT
+
+# Get all values from arguments
+vpc=${vpc}
+region=${region:-ap-southeast-2}
+service=${service}
+profile=${profile}
+bootstrap=1
+
+while [ $# -gt 0 ]; do
+   if [[ $1 == *"--"* ]]; then
+        param="${1/--/}"
+        # If the bootstrap argument is passed, set to false
+        if [ $param == "no-bootstrap" ]; then
+            declare bootstrap=0
+        else
+            declare $param="$2"
+        fi
+   fi
+  shift
+done
+
+# Error checking
+if [ -z "$service" ]; then
+    echo "Error: Please define a service name"
+    exit 1
+fi
+
+# Run bootstrap unless otherwise specified
+if [ $bootstrap == 1 ]; then
+    sudo -u node cdk bootstrap --profile $profile
+fi
+
+sudo -u node -- sh -c "SHARED_VPC_ID=$vpc AWS_REGION=$region SERVICE_NAME=$service cdk deploy --profile $profile $@"


### PR DESCRIPTION
By bundling this repo in a docker file we can allow users to run the iam script without cloning the repo. :tada: 

We'll need to publish this image to docker hub so it can easily be pulled down. 