### PR TITLE
Add DescribeStackResources permission

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -286,7 +286,8 @@ class ServiceDeployIAM extends cdk.Stack {
                          "cloudformation:DescribeStackEvents",
                          "cloudformation:UpdateStack",
                          "cloudformation:ListStackResources",
-                         "cloudformation:DescribeStackResource"
+                         "cloudformation:DescribeStackResource",
+                         "cloudformation:DescribeStackResources"
                     ]
                })
           );


### PR DESCRIPTION
Serverless requires `DescribeStackResource` and `DescribeStackResources` in some instances.
This PR adds `DescribeStackResources`