### PR TITLE
Feature/custom resource qualifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ Use the following command to deploy this into an environment:
 SHARED_VPC_ID=<OPTIONAL> AWS_REGION=<AWS_REGION> SERVICE_NAME=<SERVICE_NAME> npx cdk deploy --profile <AWS_PROFILE>
 ```
 
+##### Qualifier Injection
+
+By default the deploy role will have access to [resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html) prepended with the service name, however this may not always suffice.
+In order to work around this, the following environment variables can be provided which allow an arbitrary resource to be added to the IAM statement.
+- CLOUD_FORMATION_QUALIFIER
+- S3_QUALIFIER
+- CLOUD_WATCH_QUALIFIER
+- LAMBDA_QUALIFIER
+- STEP_FUNCTION_QUALIFIER
+- DYNAMO_DB_QUALIFIER
+- IAM_QUALIFIER
+- EVENT_BRIDGE_QUALIFIER
+- API_GATEWAY_QUALIFIER
+- SSM_QUALIFIER
+- SNS_QUALIFIER
+
+##### Example:
+```
+S3_QUALIFIER="some-other-bucket" AWS_REGION=<AWS_REGION> SERVICE_NAME=<SERVICE_NAME> npx cdk deploy --profile <AWS_PROFILE>
+```
+
 ### Next Steps
 Once this finishes a user will be created (ARN in stack output). This user will have the appropriate permissions to assume the CloudFormation role and deploy the service.
 

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -27,17 +27,17 @@ class ServiceDeployIAM extends cdk.Stack {
           const accountId = cdk.Stack.of(this).account;
           const region = cdk.Stack.of(this).region
 
-          const cloudFormationResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:cloudformation:${region}:${accountId}:stack/`, [`${serviceName}*`]);
-          const s3BucketResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:s3:::`, [`${serviceName}*`, `${serviceName}*/*`]);
-          const cloudWatchResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:logs:${region}:${accountId}:log-group:`, [`/aws/lambda/${serviceName}*`]);
-          const lambdaResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:lambda:${region}:${accountId}:function:`, [`${serviceName}*`]);
-          const stepFunctionResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:states:${region}:${accountId}:stateMachine:`, [`${serviceName}*`]);
-          const dynamoDbResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:dynamodb:${region}:${accountId}:table/`, [`${serviceName}*`]);
-          const iamResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:iam::${accountId}:role/`, [`${serviceName}*`]);
-          const eventBridgeResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:events:${region}:${accountId}:rule/`, [`${serviceName}*`]);
-          const apiGatewayResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:apigateway:${region}::`, [`/*`]);
-          const ssmDeploymentResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:ssm:${region}:${accountId}:parameter/`, [`${serviceName}*`]);
-          const snsResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:sns:${region}:${accountId}:`, [`${serviceName}*`]);
+          const cloudFormationResources = ServiceDeployIAM.formatResourceQualifier('CLOUD_FORMATION', `arn:aws:cloudformation:${region}:${accountId}:stack/`, [`${serviceName}*`]);
+          const s3BucketResources = ServiceDeployIAM.formatResourceQualifier('S3', `arn:aws:s3:::`, [`${serviceName}*`, `${serviceName}*/*`]);
+          const cloudWatchResources = ServiceDeployIAM.formatResourceQualifier('CLOUD_WATCH', `arn:aws:logs:${region}:${accountId}:log-group:`, [`/aws/lambda/${serviceName}*`]);
+          const lambdaResources = ServiceDeployIAM.formatResourceQualifier('LAMBDA', `arn:aws:lambda:${region}:${accountId}:function:`, [`${serviceName}*`]);
+          const stepFunctionResources = ServiceDeployIAM.formatResourceQualifier('STEP_FUNCTION', `arn:aws:states:${region}:${accountId}:stateMachine:`, [`${serviceName}*`]);
+          const dynamoDbResources = ServiceDeployIAM.formatResourceQualifier('DYNAMO_DB', `arn:aws:dynamodb:${region}:${accountId}:table/`, [`${serviceName}*`]);
+          const iamResources = ServiceDeployIAM.formatResourceQualifier('IAM', `arn:aws:iam::${accountId}:role/`, [`${serviceName}*`]);
+          const eventBridgeResources = ServiceDeployIAM.formatResourceQualifier('EVENT_BRIDGE', `arn:aws:events:${region}:${accountId}:rule/`, [`${serviceName}*`]);
+          const apiGatewayResources = ServiceDeployIAM.formatResourceQualifier('API_GATEWAY', `arn:aws:apigateway:${region}::`, [`/*`]);
+          const ssmDeploymentResources = ServiceDeployIAM.formatResourceQualifier('SSM', `arn:aws:ssm:${region}:${accountId}:parameter/`, [`${serviceName}*`]);
+          const snsResources = ServiceDeployIAM.formatResourceQualifier('SNS', `arn:aws:sns:${region}:${accountId}:`, [`${serviceName}*`]);
 
           const serviceRole = new Role(this, `ServiceRole-v${version}`, {
                assumedBy: new ServicePrincipal('cloudformation.amazonaws.com')
@@ -399,8 +399,12 @@ class ServiceDeployIAM extends cdk.Stack {
      }
 
      // Takes an array of qualifiers and prepends the prefix to each, returning the resulting array
-     static formatResourceQualifier(prefix: string, qualifiers: string[]): string[] {
-          return qualifiers.map((qualifier) => { return `${prefix}/${qualifier}` })
+     // Tests for injected resource qualifiers and adds these.
+     static formatResourceQualifier(serviceName: string, prefix: string, qualifiers: string[]): string[] {
+          return [
+               ...qualifiers,
+               ...[process.env[`${serviceName}_QUALIFIER`]]
+               ].map((qualifier) => { return `${prefix}/${qualifier}` })
      }
 
 

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -27,17 +27,18 @@ class ServiceDeployIAM extends cdk.Stack {
           const accountId = cdk.Stack.of(this).account;
           const region = cdk.Stack.of(this).region
 
-          const cloudFormationResources = [`arn:aws:cloudformation:${region}:${accountId}:stack/${serviceName}*`];
-          const s3BucketResources = [`arn:aws:s3:::${serviceName}*`, `arn:aws:s3:::${serviceName}*/*`]
-          const cloudWatchResources = [`arn:aws:logs:${region}:${accountId}:log-group:/aws/lambda/${serviceName}*`]
-          const lambdaResources = [`arn:aws:lambda:${region}:${accountId}:function:${serviceName}*`]
-          const stepFunctionResources = [`arn:aws:states:${region}:${accountId}:stateMachine:${serviceName}*`]
-          const dynamoDbResources = [`arn:aws:dynamodb:${region}:${accountId}:table/${serviceName}*`] 
-          const iamResources = [`arn:aws:iam::${accountId}:role/${serviceName}*`]
-          const eventBridgeResources = [`arn:aws:events:${region}:${accountId}:rule/${serviceName}*`]
-          const apiGatewayResources = [`arn:aws:apigateway:${region}::/*`]
-          const ssmDeploymentResources = [`arn:aws:ssm:${region}:${accountId}:parameter/${serviceName}*`]
-          const snsResources = [`arn:aws:sns:${region}:${accountId}:${serviceName}*`]
+          const cloudFormationResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:cloudformation:${region}:${accountId}:stack/`, [`${serviceName}*`]);
+          const s3BucketResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:s3:::`, [`${serviceName}*`, `${serviceName}*/*`]);
+          const cloudWatchResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:logs:${region}:${accountId}:log-group:`, [`/aws/lambda/${serviceName}*`]);
+          const lambdaResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:lambda:${region}:${accountId}:function:`, [`${serviceName}*`]);
+          const stepFunctionResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:states:${region}:${accountId}:stateMachine:`, [`${serviceName}*`]);
+          const dynamoDbResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:dynamodb:${region}:${accountId}:table/`, [`${serviceName}*`]);
+          const iamResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:iam::${accountId}:role/`, [`${serviceName}*`]);
+          const eventBridgeResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:events:${region}:${accountId}:rule/`, [`${serviceName}*`]);
+          const apiGatewayResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:apigateway:${region}::`, [`/*`]);
+          const ssmDeploymentResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:ssm:${region}:${accountId}:parameter/`, [`${serviceName}*`]);
+          const snsResources = ServiceDeployIAM.formatResourceQualifier(`arn:aws:sns:${region}:${accountId}:`, [`${serviceName}*`]);
+
           const serviceRole = new Role(this, `ServiceRole-v${version}`, {
                assumedBy: new ServicePrincipal('cloudformation.amazonaws.com')
           });
@@ -396,6 +397,12 @@ class ServiceDeployIAM extends cdk.Stack {
                stringValue: version
           });
      }
+
+     // Takes an array of qualifiers and prepends the prefix to each, returning the resulting array
+     static formatResourceQualifier(prefix: string, qualifiers: string[]): string[] {
+          return qualifiers.map((qualifier) => { return `${prefix}/${qualifier}` })
+     }
+
 
 }
 


### PR DESCRIPTION
This PR adds the ability to pass custom qualifiers for each resource.

This can be used to allow arbitrary AWS resources (That are not prepended with the service name) to be added to the IAM statement.