### PR TITLE
Hotfix - Fixes for custom resource qualifiers

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -27,16 +27,16 @@ class ServiceDeployIAM extends cdk.Stack {
           const accountId = cdk.Stack.of(this).account;
           const region = cdk.Stack.of(this).region
 
-          const cloudFormationResources = ServiceDeployIAM.formatResourceQualifier('CLOUD_FORMATION', `arn:aws:cloudformation:${region}:${accountId}:stack/`, [`${serviceName}*`]);
+          const cloudFormationResources = ServiceDeployIAM.formatResourceQualifier('CLOUD_FORMATION', `arn:aws:cloudformation:${region}:${accountId}:stack`, [`${serviceName}*`]);
           const s3BucketResources = ServiceDeployIAM.formatResourceQualifier('S3', `arn:aws:s3:::`, [`${serviceName}*`, `${serviceName}*/*`]);
           const cloudWatchResources = ServiceDeployIAM.formatResourceQualifier('CLOUD_WATCH', `arn:aws:logs:${region}:${accountId}:log-group:`, [`/aws/lambda/${serviceName}*`]);
           const lambdaResources = ServiceDeployIAM.formatResourceQualifier('LAMBDA', `arn:aws:lambda:${region}:${accountId}:function:`, [`${serviceName}*`]);
           const stepFunctionResources = ServiceDeployIAM.formatResourceQualifier('STEP_FUNCTION', `arn:aws:states:${region}:${accountId}:stateMachine:`, [`${serviceName}*`]);
-          const dynamoDbResources = ServiceDeployIAM.formatResourceQualifier('DYNAMO_DB', `arn:aws:dynamodb:${region}:${accountId}:table/`, [`${serviceName}*`]);
+          const dynamoDbResources = ServiceDeployIAM.formatResourceQualifier('DYNAMO_DB', `arn:aws:dynamodb:${region}:${accountId}:table`, [`${serviceName}*`]);
           const iamResources = ServiceDeployIAM.formatResourceQualifier('IAM', `arn:aws:iam::${accountId}:role/`, [`${serviceName}*`]);
-          const eventBridgeResources = ServiceDeployIAM.formatResourceQualifier('EVENT_BRIDGE', `arn:aws:events:${region}:${accountId}:rule/`, [`${serviceName}*`]);
+          const eventBridgeResources = ServiceDeployIAM.formatResourceQualifier('EVENT_BRIDGE', `arn:aws:events:${region}:${accountId}:rule`, [`${serviceName}*`]);
           const apiGatewayResources = ServiceDeployIAM.formatResourceQualifier('API_GATEWAY', `arn:aws:apigateway:${region}::`, [`/*`]);
-          const ssmDeploymentResources = ServiceDeployIAM.formatResourceQualifier('SSM', `arn:aws:ssm:${region}:${accountId}:parameter/`, [`${serviceName}*`]);
+          const ssmDeploymentResources = ServiceDeployIAM.formatResourceQualifier('SSM', `arn:aws:ssm:${region}:${accountId}:parameter`, [`${serviceName}*`]);
           const snsResources = ServiceDeployIAM.formatResourceQualifier('SNS', `arn:aws:sns:${region}:${accountId}:`, [`${serviceName}*`]);
 
           const serviceRole = new Role(this, `ServiceRole-v${version}`, {
@@ -403,8 +403,8 @@ class ServiceDeployIAM extends cdk.Stack {
      static formatResourceQualifier(serviceName: string, prefix: string, qualifiers: string[]): string[] {
           return [
                ...qualifiers,
-               ...[process.env[`${serviceName}_QUALIFIER`]]
-               ].map((qualifier) => { return `${prefix}/${qualifier}` })
+               ...[process.env[`${serviceName}_QUALIFIER`] ?? false]
+               ].filter(Boolean).map((qualifier) => { return `${prefix}/${qualifier}` })
      }
 
 


### PR DESCRIPTION
The new version was creating resources like:
```
        {
            "Action": [
                "cloudformation:CreateStack",
                "cloudformation:DescribeStacks",
                "cloudformation:DeleteStack",
                "cloudformation:DescribeStackEvents",
                "cloudformation:UpdateStack",
                "cloudformation:ListStackResources",
                "cloudformation:DescribeStackResource",
                "cloudformation:DescribeStackResources"
            ],
            "Resource": [
                "arn:aws:cloudformation:us-east-1:1234567890:stack//some-service-name*",
                "arn:aws:cloudformation:us-east-1:1234567890:stack//undefined"
            ],
            "Effect": "Allow"
        },
```
So I have added the hotfixes below:

1. Removed trailing / from prefixes passed in as it is added in the formatResourceQualifier function and causes double ups e.g. arn:aws:cloudformation:us-east-1:1234567890:stack//some-service-name*

1. Added check and filter for missing service qualifier environment variables otherwise you end up with extra resources like arn:aws:cloudformation:us-east-1:1234567890:stack//undefined

New Cloudformation output looks like:
Without a custom qualifier
```yml
          - Action:
              - cloudformation:CreateStack
              - cloudformation:DescribeStacks
              - cloudformation:DeleteStack
              - cloudformation:DescribeStackEvents
              - cloudformation:UpdateStack
              - cloudformation:ListStackResources
              - cloudformation:DescribeStackResource
              - cloudformation:DescribeStackResources
            Effect: Allow
            Resource:
              Fn::Join:
                - ""
                - - "arn:aws:cloudformation:"
                  - Ref: AWS::Region
                  - ":"
                  - Ref: AWS::AccountId
                  - :stack/some-service-name*
```

With custom qualifier
```yml
          - Action:
              - cloudformation:CreateStack
              - cloudformation:DescribeStacks
              - cloudformation:DeleteStack
              - cloudformation:DescribeStackEvents
              - cloudformation:UpdateStack
              - cloudformation:ListStackResources
              - cloudformation:DescribeStackResource
              - cloudformation:DescribeStackResources
            Effect: Allow
            Resource:
              - Fn::Join:
                  - ""
                  - - "arn:aws:cloudformation:"
                    - Ref: AWS::Region
                    - ":"
                    - Ref: AWS::AccountId
                    - :stack/rag-sales-scheduler*
              - Fn::Join:
                  - ""
                  - - "arn:aws:cloudformation:"
                    - Ref: AWS::Region
                    - ":"
                    - Ref: AWS::AccountId
                    - :stack/some-qualifier
```