### PR TITLE
Export cdk output with a custom prefix; include additional permission

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -11,6 +11,7 @@ import {
    User
 } from '@aws-cdk/aws-iam';
 
+var EXPORT_PREFIX = process.env.EXPORT_PREFIX
 const SERVICE_NAME = process.env.SERVICE_NAME
 const SHARED_VPC_ID = process.env.SHARED_VPC_ID
 const STACK_SUFFIX = '-deploy-iam'
@@ -31,12 +32,14 @@ class ServiceDeployIAM extends cdk.Stack {
           const s3BucketResources = [`arn:aws:s3:::${serviceName}*`, `arn:aws:s3:::${serviceName}*/*`]
           const cloudWatchResources = [`arn:aws:logs:${region}:${accountId}:log-group:/aws/lambda/${serviceName}*`]
           const lambdaResources = [`arn:aws:lambda:${region}:${accountId}:function:${serviceName}*`]
-          const stepFunctionResources = [`arn:aws:states:${region}:${accountId}:stateMachine:${serviceName}*`]
+          // const stepFunctionResources = [`arn:aws:states:${region}:${accountId}:stateMachine:${serviceName}*`]
+          // To cater the requirement that lmbda's naming is being exceeding character limit
+          const stepFunctionResources = [`arn:aws:states:${region}:${accountId}:stateMachine:*`]
           const dynamoDbResources = [`arn:aws:dynamodb:${region}:${accountId}:table/${serviceName}*`] 
           const iamResources = [`arn:aws:iam::${accountId}:role/${serviceName}*`]
           const eventBridgeResources = [`arn:aws:events:${region}:${accountId}:rule/${serviceName}*`]
           const apiGatewayResources = [`arn:aws:apigateway:${region}::/*`]
-          const ssmDeploymentResources = [`arn:aws:ssm:${region}:${accountId}:parameter/${serviceName}*`]
+          const ssmDeploymentResources = [`arn:aws:ssm:${region}:${accountId}:*${serviceName}*`]
           const snsResources = [`arn:aws:sns:${region}:${accountId}:${serviceName}*`]
           const serviceRole = new Role(this, `ServiceRole-v${version}`, {
                assumedBy: new ServicePrincipal('cloudformation.amazonaws.com')
@@ -62,7 +65,6 @@ class ServiceDeployIAM extends cdk.Stack {
                })
           );
 
-
           if (SHARED_VPC_ID) {
                // Secutiry Groups
                serviceRole.addToPolicy(
@@ -70,11 +72,23 @@ class ServiceDeployIAM extends cdk.Stack {
                          effect: Effect.ALLOW,
                          resources: ['*'],
                          actions: [            
+                              "ec2:CreateNetworkInterface",
+                              "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+                              "ec2:DeleteTags",
+                              "ec2:DescribeNetworkInterfaces",
+                              "ec2:DescribeTags",
                               "ec2:CreateSecurityGroup",
+                              "ec2:CreateTags",
+                              "ec2:DeleteSecurityGroup",
+                              "ec2:DeleteNetworkInterface",
+                              "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
                               "ec2:DescribeSecurityGroups",
                               "ec2:DescribeSubnets",
                               "ec2:DescribeVpcs",
-                              "ec2:createTags"
+                              "ec2:CreateNetworkInterface",
+                              "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+                              "ec2:DeleteTags",
+                              "dynamodb:*"
                          ]
                     })
                );
@@ -97,21 +111,67 @@ class ServiceDeployIAM extends cdk.Stack {
 
           // CloudWatch policy
           serviceRole.addToPolicy(
+                    new PolicyStatement({
+                         effect: Effect.ALLOW,
+                         resources: ["arn:aws:iam::*:role/aws-service-role/events.amazonaws.com/AWSServiceRoleForCloudWatchEvents*"],
+                         conditions: {
+                              "StringLike": {
+                                   "iam:AWSServiceName": "events.amazonaws.com"
+                               }
+                         },
+                         actions: [            
+                              "iam:CreateServiceLinkedRole"
+                         ]
+                    })
+          );
+
+          serviceRole.addToPolicy(
                new PolicyStatement({
                     effect: Effect.ALLOW,
-                    resources: cloudWatchResources,
+                    resources: ["*"],
                     actions: [            
-                         "logs:CreateLogGroup",
-                         "logs:DescribeLogGroup",
-                         "logs:DeleteLogGroup",
-                         "logs:CreateLogStream",
-                         "logs:DescribeLogStreams",
-                         "logs:DeleteLogStream",
-                         "logs:FilterLogEvents"
+                         "autoscaling:Describe*",
+                         "cloudwatch:*",
+                         "logs:*",
+                         "sns:*",
+                         "iam:GetPolicy",
+                         "iam:GetPolicyVersion",
+                         "iam:GetRole"
+                    ]
+               })
+          );
+          // Lambda Role Creation
+          serviceRole.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: ["*"],
+                    actions: [            
+                        "events:*"
                     ]
                })
           );
 
+          serviceRole.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: [`arn:aws:iam::${accountId}:role/horizon*`],
+                    actions: [            
+                        "iam:*"
+                    ]
+               })
+          );
+
+
+          // SQS Full Access
+          serviceRole.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: ["*"],
+                    actions: [            
+                         "sqs:*"
+                    ]
+               })
+          );
 
           // Lambda policy
           serviceRole.addToPolicy(
@@ -119,24 +179,68 @@ class ServiceDeployIAM extends cdk.Stack {
                     effect: Effect.ALLOW,
                     resources: lambdaResources,
                     actions: [            
-                         "lambda:GetFunction",
-                         "lambda:CreateFunction",
-                         "lambda:DeleteFunction",
-                         "lambda:UpdateFunctionConfiguration",
-                         "lambda:UpdateFunctionCode",
-                         "lambda:ListVersionsByFunction",
-                         "lambda:PublishVersion",
-                         "lambda:CreateAlias",
-                         "lambda:DeleteAlias",
-                         "lambda:UpdateAlias",
-                         "lambda:GetFunctionConfiguration",
-                         "lambda:AddPermission",
-                         "lambda:RemovePermission",
-                         "lambda:InvokeFunction"
+                         "cloudformation:DescribeStacks",
+                         "cloudformation:ListStackResources",
+                         "cloudwatch:ListMetrics",
+                         "cloudwatch:GetMetricData",
+                         "ec2:DescribeSecurityGroups",
+                         "ec2:DescribeSubnets",
+                         "ec2:DescribeVpcs",
+                         "kms:ListAliases",
+                         "iam:GetPolicy",
+                         "iam:GetPolicyVersion",
+                         "iam:GetRole",
+                         "iam:GetRolePolicy",
+                         "iam:ListAttachedRolePolicies",
+                         "iam:ListRolePolicies",
+                         "iam:ListRoles",
+                         "lambda:*",
+                         "logs:DescribeLogGroups",
+                         "states:DescribeStateMachine",
+                         "states:ListStateMachines",
+                         "tag:GetResources",
+                         "xray:GetTraceSummaries",
+                         "ec2:CreateSecurityGroup",
+                         "xray:BatchGetTraces",
+                         "ec2:CreateNetworkInterface",
+                         "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+                         "ec2:DeleteTags",
+                         "ec2:DescribeNetworkInterfaces",
+                         "ec2:DescribeTags",
+                         "ec2:CreateTags",
+                         "ec2:DeleteSecurityGroup",
+                         "ec2:DeleteNetworkInterface",
+                         "ec2:UpdateSecurityGroupRuleDescriptionsIngress"
                     ]
                })
           );
-
+          // Lambda IAM Pass role
+          serviceRole.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: ['*'],
+                    actions: [            
+                       "iam:PassRole"
+                    ],
+                    conditions: {
+                         "StringEquals": {
+                              "iam:PassedToService": "lambda.amazonaws.com"
+                          }
+                    },
+               })
+          );    
+          // Lambda Log Streams
+          serviceRole.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: ["arn:aws:logs:*:*:log-group:/aws/lambda/*"],
+                    actions: [            
+                         "logs:DescribeLogStreams",
+                         "logs:GetLogEvents",
+                         "logs:FilterLogEvents"
+                    ]
+               })
+          );
 
           serviceRole.addToPolicy(
                new PolicyStatement({
@@ -193,25 +297,67 @@ class ServiceDeployIAM extends cdk.Stack {
                     effect: Effect.ALLOW,
                     resources: dynamoDbResources,
                     actions: [            
-                         "dynamodb:DescribeTable",
-                         "dynamodb:CreateTable",
-                         "dynamodb:UpdateTable",
-                         "dynamodb:DeleteTable",
+                         "dynamodb:*"
                     ]
                })
           );
-
+          // DynamoDB policy CloudWatch
+          serviceRole.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: ["arn:aws:cloudwatch:*:*:insight-rule/DynamoDBContributorInsights*"],
+                    actions: [            
+                         "cloudwatch:GetInsightRuleReport"
+                    ]
+               })
+          );
+          // DynamoDB IAM Pass Role
+          serviceRole.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: ["*"],
+                    actions: [            
+                         "iam:PassRole"
+                    ],
+                    conditions: {
+                         "StringLike": {
+                              "iam:PassedToService": [
+                                  "application-autoscaling.amazonaws.com",
+                                  "application-autoscaling.amazonaws.com.cn",
+                                  "dax.amazonaws.com"
+                              ]
+                          } 
+                    }
+               })
+          );
+          // DynamoDB IAM Service Linked Role
+          serviceRole.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: ["*"],
+                    actions: [            
+                         "iam:CreateServiceLinkedRole"
+                    ],
+                    conditions: {
+                         "StringLike": {
+                              "iam:AWSServiceName": [
+                                   "replication.dynamodb.amazonaws.com",
+                                   "dax.amazonaws.com",
+                                   "dynamodb.application-autoscaling.amazonaws.com",
+                                   "contributorinsights.dynamodb.amazonaws.com",
+                                   "kinesisreplication.dynamodb.amazonaws.com"
+                              ]
+                         }
+                    }
+               })
+          );
           // StepFunctions policy 
           serviceRole.addToPolicy(
                new PolicyStatement({
                     effect: Effect.ALLOW,
                     resources: stepFunctionResources,
                     actions: [            
-                         "states:CreateStateMachine",
-                         "states:UpdateStateMachine",
-                         "states:DeleteStateMachine",
-                         "states:DescribeStateMachine",
-                         "states:TagResource",
+                         "states:*"
                     ]
                })
           );
@@ -270,7 +416,8 @@ class ServiceDeployIAM extends cdk.Stack {
                     effect: Effect.ALLOW,
                     resources: ['*'],
                     actions: [
-                         "cloudformation:ValidateTemplate",
+                         "cloudformation:*",
+                     
                     ]
                })
           );
@@ -286,7 +433,8 @@ class ServiceDeployIAM extends cdk.Stack {
                          "cloudformation:DescribeStackEvents",
                          "cloudformation:UpdateStack",
                          "cloudformation:ListStackResources",
-                         "cloudformation:DescribeStackResource"
+                         "cloudformation:DescribeStackResource",
+                        
                     ]
                })
           );
@@ -322,15 +470,21 @@ class ServiceDeployIAM extends cdk.Stack {
                          "s3:DeleteObject",
                          "s3:PutObject",
                          "s3:GetObject",
-                         "s3:GetBucketLocation"
+                         "s3:GetBucketLocation",
+                         "s3:CreateBucket",
+                         "s3:GetEncryptionConfiguration",
+                         "s3:PutEncryptionConfiguration",
+                         "s3:PutBucketPolicy"
                     ]
                })
           );
+          //  See https://github.com/serverless/serverless/issues/5919
           deployGroup.addToPolicy(
                new PolicyStatement({
                     effect: Effect.ALLOW,
                     resources: ['*'],
                     actions: [
+                         "apigateway:GET",
                          "s3:ListAllMyBuckets",
                     ]
                })
@@ -360,19 +514,30 @@ class ServiceDeployIAM extends cdk.Stack {
 
           deployUser.addToGroup(deployGroup);
 
-          new cdk.CfnOutput(this, 'DeployUserName', {
-               description: 'PublisherUser',
+          // Export CDK Output
+          if (!EXPORT_PREFIX){
+               EXPORT_PREFIX=serviceName;
+          }
+          if(!EXPORT_PREFIX.endsWith('-')){
+               EXPORT_PREFIX=EXPORT_PREFIX.concat("-");
+          }
+        
+          new cdk.CfnOutput(this, `${EXPORT_PREFIX}DeployUserName`, {
+               description: "PublisherUser",
+               exportName: `${EXPORT_PREFIX}serverless-deployer-username`,
                value: deployUser.userName,
           });
 
-          new cdk.CfnOutput(this, 'DeployRoleArn', {
+          new cdk.CfnOutput(this, `${EXPORT_PREFIX}DeployRoleArn`, {
                value: serviceRole.roleArn,
-               description: 'The ARN of the CloudFormation service role',
+               exportName: `${EXPORT_PREFIX}serverless-deployer-role-arn`,
+               description: "The ARN of the CloudFormation service role",
           });
 
-          new cdk.CfnOutput(this, 'Version', {
+          new cdk.CfnOutput(this, `${EXPORT_PREFIX}Version`, {
                value: version,
-               description: 'The version of the resources that are currently provisioned in this stack',
+               exportName: `${EXPORT_PREFIX}cdk-stack-version`,
+               description: `The version of the resources that are currently provisioned in this stack`,
           });
 
           const parameterName = `/serverless-deploy-iam/${serviceName}/version`;


### PR DESCRIPTION
This PR should be reviewed as suggested changes are based on RAG's requirements.
Focus: 
- Export `cdk` output with a custom prefix
- Modify default permissions