### PR TITLE
Add empty prefix to SNS topic resource generation

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -37,7 +37,7 @@ class ServiceDeployIAM extends cdk.Stack {
           const eventBridgeResources = ServiceDeployIAM.formatResourceQualifier('EVENT_BRIDGE', `arn:aws:events:${region}:${accountId}:rule`, [`${serviceName}*`]);
           const apiGatewayResources = ServiceDeployIAM.formatResourceQualifier('API_GATEWAY', `arn:aws:apigateway:${region}::`, [`*`]);
           const ssmDeploymentResources = ServiceDeployIAM.formatResourceQualifier('SSM', `arn:aws:ssm:${region}:${accountId}:parameter`, [`${serviceName}*`]);
-          const snsResources = ServiceDeployIAM.formatResourceQualifier('SNS', `arn:aws:sns:${region}:${accountId}:`, [`${serviceName}*`]);
+          const snsResources = ServiceDeployIAM.formatResourceQualifier('SNS', `arn:aws:sns:${region}:${accountId}:`, [`${serviceName}*`], "");
 
           const serviceRole = new Role(this, `ServiceRole-v${version}`, {
                assumedBy: new ServicePrincipal('cloudformation.amazonaws.com')


### PR DESCRIPTION
This PR adds an empty prefix value to the SNS resource ARN generation call as otherwise it returns ARN's looking like:
```
arn:aws:sns:us-east-1:123456789:/some-service-name-staging
```

instead of:

```
arn:aws:sns:us-east-1:123456789:some-service-name-staging
```