### PR TITLE
DO-1166: Add Invocation and Get permission for the deploy user

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -376,6 +376,17 @@ class ServiceDeployIAM extends cdk.Stack {
                })
           );
 
+          deployGroup.addToPolicy(
+               new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    resources: lambdaResources,
+                    actions: [
+                         "lambda:GetFunction",
+                         "lambda:InvokeFunction"
+                    ]
+               })
+          );
+
 
           deployUser.addToGroup(deployGroup);
 


### PR DESCRIPTION
This PR adds the GET and Invoke permission for lambda functions to the deployment group. This is so that the deploy user can invoke lambda functions after the deploy to register webhooks etc.
