### PR TITLE
Add non-empty default service name fallback

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -12,7 +12,7 @@ import {
    User
 } from '@aws-cdk/aws-iam';
 
-const SERVICE_NAME = process.env.SERVICE_NAME ? process.env.SERVICE_NAME : ''
+const SERVICE_NAME = process.env.SERVICE_NAME ? process.env.SERVICE_NAME : 'unknown-service'
 const SHARED_VPC_ID = process.env.SHARED_VPC_ID
 const STACK_SUFFIX = '-deploy-iam'
 const EXPORT_PREFIX = process.env.EXPORT_PREFIX ? process.env.EXPORT_PREFIX : SERVICE_NAME


### PR DESCRIPTION
Adds a non empty default for `STACK_NAME` this is mainly to ensure `cdk bootstrap` actions to not fail without a service name passed in.